### PR TITLE
Updated unity SDK API to be more in line with JS and Unreal

### DIFF
--- a/Scripts/Api.cs
+++ b/Scripts/Api.cs
@@ -100,18 +100,19 @@ namespace CharismaSDK
             }
 
             var data = Encoding.UTF8.GetString(request.downloadHandler.data);
+            CreatePlaythroughTokenResponse deserialized;
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<CreatePlaythroughTokenResponse>(data);
-                callback?.Invoke(deserialized);
+                deserialized = JsonConvert.DeserializeObject<CreatePlaythroughTokenResponse>(data);
                 Logger.Log("Token request complete");
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not deserialize token. Are you using the correct API key?: {e}");
-                throw;
+                throw new Exception($"Could not deserialize token. Are you using the correct API key? ", e);
             }
+
+            callback?.Invoke(deserialized);
 
             // Need to dispose of WebRequest to prevent following error:
             // "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details."
@@ -140,18 +141,18 @@ namespace CharismaSDK
             }
 
             var data = Encoding.UTF8.GetString(request.downloadHandler.data);
+            CreateConversationResponse deserialized;
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<CreateConversationResponse>(data);
-                callback?.Invoke(deserialized.ConversationUuid);
+                deserialized = JsonConvert.DeserializeObject<CreateConversationResponse>(data);
                 Logger.Log("Conversation request complete");
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not generate conversation; {e}");
-                throw;
+                throw new Exception($"Could not generate conversation; ", e);
             }
+            callback?.Invoke(deserialized.ConversationUuid);
 
             // Need to dispose of WebRequest to prevent following error:
             // "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details."
@@ -178,7 +179,6 @@ namespace CharismaSDK
             }
 
             var request = UnityWebRequest.Get($"{BaseUrl}/play/message-history" + CreateQueryString(requestParams));
-            request.method = "GET"; 
             request.SetRequestHeader("Authorization", $"Bearer {token}");
 
             Logger.Log("Requesting message history...");
@@ -192,18 +192,18 @@ namespace CharismaSDK
             }
 
             var data = Encoding.UTF8.GetString(request.downloadHandler.data);
+            GetMessageHistoryResponse deserialized;
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<GetMessageHistoryResponse>(data);
-                callback?.Invoke(deserialized);
+                deserialized = JsonConvert.DeserializeObject<GetMessageHistoryResponse>(data);
                 Logger.Log("Message history request complete");
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not get message history; {e}");
-                throw;
+                throw new Exception($"Could not get message history;", e);
             }
+            callback?.Invoke(deserialized);
 
             // Need to dispose of WebRequest to prevent following error:
             // "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details."
@@ -218,7 +218,6 @@ namespace CharismaSDK
         public static IEnumerator GetPlaythroughInfo(string token, Action<GetPlaythroughInfoResponse> callback)
         {
             var request = UnityWebRequest.Get($"{BaseUrl}/play/playthrough-info");
-            request.method = "GET";
             request.SetRequestHeader("Authorization", $"Bearer {token}");
 
             Logger.Log("Requesting playthrough info...");
@@ -232,18 +231,19 @@ namespace CharismaSDK
             }
 
             var data = Encoding.UTF8.GetString(request.downloadHandler.data);
+            GetPlaythroughInfoResponse deserialized;
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<GetPlaythroughInfoResponse>(data);
-                callback?.Invoke(deserialized);
+                deserialized = JsonConvert.DeserializeObject<GetPlaythroughInfoResponse>(data);
                 Logger.Log("Playthrough info request complete");
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not generate playthrough information; {e}");
-                throw;
+                throw new Exception($"Could not generate playthrough information.", e);
             }
+
+            callback?.Invoke(deserialized);
 
             // Need to dispose of WebRequest to prevent following error:
             // "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details."
@@ -260,20 +260,16 @@ namespace CharismaSDK
         {
             var count = recallSaveValues.Count;
 
-            Logger.Log($"Setting memories - count: {count}");
-
-            object[] memoriesToSet = new object[count];
-            int i = 0;
+            Logger.Log($"Setting {count} memories...");
+            List<object> memoriesToSet = new List<object>();
             foreach (var entry in recallSaveValues)
             {
-                var memoryToSet = new
+                Logger.Log($"Setting memory `{entry.Key}` with value `{entry.Value}`...");
+                memoriesToSet.Add(new
                 {
                     recallValue = entry.Key,
                     saveValue = entry.Value,
-                };
-                Logger.Log($"Setting memory `{memoryToSet.recallValue}` with value `{memoryToSet.saveValue}`...");
-                memoriesToSet[i] = memoryToSet;
-                i++;
+                });
             }
 
             object requestParams = new
@@ -342,18 +338,19 @@ namespace CharismaSDK
             }
 
             var data = Encoding.UTF8.GetString(request.downloadHandler.data);
+            ForkPlaythroughResponse deserialized;
 
             try
             {
-                var deserialized = JsonConvert.DeserializeObject<ForkPlaythroughResponse>(data);
-                callback?.Invoke(deserialized);
+                deserialized = JsonConvert.DeserializeObject<ForkPlaythroughResponse>(data);
                 Logger.Log("Fork request complete");
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not request playthrough fork; {e}");
-                throw;
+                throw new Exception($"Could not request playthrough fork", e);
             }
+
+            callback?.Invoke(deserialized);
 
             // Need to dispose of WebRequest to prevent following error:
             // "A Native Collection has not been disposed, resulting in a memory leak. Enable Full StackTraces to get more details."
@@ -396,8 +393,7 @@ namespace CharismaSDK
             }
             catch (Exception e)
             {
-                Logger.LogError($"Could not reset playthrough; {e}");
-                throw;
+                throw new Exception($"Could not reset playthrough;", e);
             }
 
             callback?.Invoke();

--- a/Scripts/Api.cs
+++ b/Scripts/Api.cs
@@ -161,7 +161,7 @@ namespace CharismaSDK
         /// </summary>
         /// <param name="token">Valid play-through token.</param>
         /// <param name="conversationUuid">Active generated Conversation ID.</param>
-        /// <param name="minEventId"></param>
+        /// <param name="minEventId">Minimum event Id from which to start reading message history. Only assign if you want messages after a certain point</param>
         /// <param name="callback">Called when a valid history is generated.</param>
         public static IEnumerator GetMessageHistory(string token, string conversationUuid, string minEventId, Action<GetMessageHistoryResponse> callback)
         {

--- a/Scripts/CharismaSDK.asmdef
+++ b/Scripts/CharismaSDK.asmdef
@@ -1,0 +1,16 @@
+{
+    "name": "CharismaSDK",
+    "rootNamespace": "",
+    "references": [
+        "GUID:cbd398b7a0281441c9a6800be1ca9717"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Scripts/CharismaSDK.asmdef.meta
+++ b/Scripts/CharismaSDK.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c6bb2dee62903ee4c8209eaaad82d92a
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Events.cs
+++ b/Scripts/Events.cs
@@ -170,6 +170,16 @@ namespace CharismaSDK.Events
 
     [Preserve]
     [Serializable]
+    public class Impact
+    {
+        public int id;
+        public string impact;
+        public bool isImpactShareable;
+        public string impactImageUrl;
+    }
+
+    [Preserve]
+    [Serializable]
     public class ActiveEffect
     {
         public int id;

--- a/Scripts/Events.cs
+++ b/Scripts/Events.cs
@@ -170,16 +170,6 @@ namespace CharismaSDK.Events
 
     [Preserve]
     [Serializable]
-    public class Impact
-    {
-        public int id;
-        public string impact;
-        public bool isImpactShareable;
-        public string impactImageUrl;
-    }
-
-    [Preserve]
-    [Serializable]
     public class ActiveEffect
     {
         public int id;

--- a/Scripts/Tests.meta
+++ b/Scripts/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b9475eaf6cc55a648aeb29e302c0d6a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tests/ApiTests.cs
+++ b/Scripts/Tests/ApiTests.cs
@@ -1,0 +1,321 @@
+using NUnit.Framework;
+using System;
+using System.Collections;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+namespace CharismaSDK.Tests
+{
+    [TestFixture]
+    public class ApiTests
+    {
+        #region Test Variables
+
+        // Pre-made story metadata, used to inform the tests
+        private const int TEST_CASE_TOKENID = 15452;
+        private const int TEST_CASE_VERSIONID = -1;
+        private const string TEST_CASE_APIKEY = "cff59833-71fc-42c4-9077-220d42aef65a";
+
+        private const string EXPECTED_REPLY_FROM_ACTOR = "Howdy!";
+
+        private const string DRAFT_MEMORY_RECALL_VALUE = "delicious";
+        private const string MEMORY_SAVE_VALUE_TO_ASSIGN = "banana";
+
+        #endregion
+
+        private string _conversationUuid;
+        private string _tokenId;
+        private Playthrough _charisma;
+
+        private CreatePlaythroughTokenParams _playthroughTokenParams;
+
+        [OneTimeSetUp]
+        public void Setup()
+        {
+            _playthroughTokenParams = new CreatePlaythroughTokenParams(TEST_CASE_TOKENID, TEST_CASE_VERSIONID, TEST_CASE_APIKEY);
+        }
+
+        [SetUp]
+        public void RepeatSetup()
+        {
+            _conversationUuid = null;
+            _tokenId = null;
+            _charisma = default;
+        }
+
+        [TearDown]
+        public void Teardown()
+        {
+        }
+
+        #region Tests
+
+        [Category("API")]
+        [UnityTest]
+        public IEnumerator LoadPlaythrough()
+        {
+            string resultUuid = null;
+            string resultToken = null;
+
+            var task = CharismaAPI.CreatePlaythroughToken(_playthroughTokenParams, callback: (response) =>
+            {
+                // assign token and uuid post callback
+                resultUuid = response.PlaythroughUuid;
+                resultToken = response.Token;
+            }
+            );
+
+            yield return task;
+
+            Assert.AreNotEqual(resultUuid, null, "Resulting Uid is null. Callback did not get called? Playthrough request failed.");
+            Assert.AreNotEqual(resultToken, null, "Resulting Uid is null. Callback did not get called? Playthrough request failed.");
+        }
+
+        [Category("API")]
+        [UnityTest]
+        public IEnumerator GetMessageHistory()
+        {
+            GetMessageHistoryResponse messageHistory = default;
+
+            IEnumerator playthroughCreationCallback = default;
+            IEnumerator getMessageHistory = default;
+
+            IEnumerator createToken = CharismaAPI.CreatePlaythroughToken(_playthroughTokenParams, callback: (tokenResponse) =>
+            {
+                playthroughCreationCallback = CharismaAPI.CreateConversation(token: tokenResponse.Token, callback: conversationUuid =>
+                {
+                    _conversationUuid = conversationUuid;
+
+                    _charisma = new Playthrough(
+                        tokenResponse.Token,
+                        tokenResponse.PlaythroughUuid
+                    );
+
+                    // hook up on message callback before attempting to connect
+                    _charisma.OnMessage += (message) =>
+                    {
+                        getMessageHistory = CharismaAPI.GetMessageHistory(tokenResponse.Token, _conversationUuid, null, callback: (messageHistoryResponse) =>
+                        {
+                            messageHistory = messageHistoryResponse;
+                        }
+                        );
+                    };
+
+                    _charisma.Connect(onReadyCallback: () =>
+                    {
+                        _charisma.Start(_conversationUuid);
+                    });
+                });
+            });
+
+            yield return createToken;
+        
+            // adding padding to accomodate for server response waiting time
+            yield return StartAndWaitUntil(playthroughCreationCallback, () =>
+            {
+                return _charisma.IsReadyToPlay;
+            });
+
+            // send conversation reply
+            _charisma.Reply(_conversationUuid, "Hi");
+
+            // need to wait for reply to be handled and message received callback to be received
+            yield return WaitUntil(() =>
+            {
+                return getMessageHistory != default;
+            });
+
+            // adding padding to accomodate for message history callback
+            yield return StartAndWaitUntil(getMessageHistory, () =>
+            {
+                return messageHistory != default;
+            });
+
+            Assert.IsTrue(messageHistory != default, "Message History was never returned");
+            Assert.IsNotEmpty(messageHistory.Messages, null, "Message history is empty.");
+            Assert.IsTrue(messageHistory.Messages[0].message.text == EXPECTED_REPLY_FROM_ACTOR, null, "Expected message does not match!");
+        }
+
+        [Category("API")]
+        [UnityTest]
+        public IEnumerator GetPlaythroughInfo()
+        {
+            GetPlaythroughInfoResponse playthroughInfo = default;
+
+            IEnumerator getPlaythroughInfoCall = default;
+
+            IEnumerator createToken = CharismaAPI.CreatePlaythroughToken(_playthroughTokenParams, callback: (tokenResponse) =>
+            {
+                getPlaythroughInfoCall = CharismaAPI.GetPlaythroughInfo(tokenResponse.Token, callback: (playthroughInfoResult) =>
+                {
+                    playthroughInfo = playthroughInfoResult;
+                }
+                );
+            });
+
+            // adding padding to accomodate for token generation
+            yield return StartAndWaitUntil(createToken, () =>
+            {
+                return getPlaythroughInfoCall != default;
+            });
+
+            yield return getPlaythroughInfoCall;
+
+            Assert.IsTrue(playthroughInfo != default, "Playthrough Info was never returned.");
+        }
+
+        [Category("API")]
+        [UnityTest]
+        public IEnumerator SetMemorySingle()
+        {
+            IEnumerator setMemory = default;
+            IEnumerator getPlaythroughInfoPostCall = default;
+
+            string memoryRecallValue = DRAFT_MEMORY_RECALL_VALUE;
+            string memorySaveValue = MEMORY_SAVE_VALUE_TO_ASSIGN;
+
+            bool memoryChangePerformedSuccesfully = false;
+
+            IEnumerator createToken = CharismaAPI.CreatePlaythroughToken(_playthroughTokenParams, callback: (tokenResponse) =>
+            {
+                setMemory = CharismaAPI.SetMemory(tokenResponse.Token, memoryRecallValue, memorySaveValue, callback: () =>
+                {
+                    getPlaythroughInfoPostCall = CharismaAPI.GetPlaythroughInfo(tokenResponse.Token, callback: (playthroughInfoResult) =>
+                    {
+                        // check that the memories were set correctly
+                        foreach(var memory in playthroughInfoResult.Memories)
+                        {
+                            if(memory.recallValue == memoryRecallValue)
+                            {
+                                if(memory.saveValue == memorySaveValue)
+                                {
+                                    memoryChangePerformedSuccesfully = true;
+                                }
+                            }
+
+                        }
+
+                    }
+                    );
+                }
+                );
+            });
+
+            // adding padding to accomodate for token generation
+            yield return StartAndWaitUntil(createToken, () =>
+            {
+                return setMemory != default;
+            });
+
+            // adding padding to accomodate for connection latency
+            yield return StartAndWaitUntil(setMemory, () =>
+            {
+                return getPlaythroughInfoPostCall != default;
+            });
+
+            yield return getPlaythroughInfoPostCall;
+
+            Assert.IsTrue(memoryChangePerformedSuccesfully, "Memory was not set correctly.");
+        }
+
+        [Category("API")]
+        [UnityTest]
+        public IEnumerator ForkPlaythroughToken()
+        {
+            IEnumerator forkPlaythrough = default;
+            IEnumerator playthroughCreationCallback = default;
+            IEnumerator getDraftPlaythroughInfoCall = default;
+            IEnumerator getForkedPlaythroughInfoCall = default;
+
+            GetPlaythroughInfoResponse draftPlaythroughInfo = default;
+            GetPlaythroughInfoResponse forkedPlaythroughInfo = default;
+
+            IEnumerator createPlaythroughToken = CharismaAPI.CreatePlaythroughToken(_playthroughTokenParams, callback: (tokenResponse) =>
+            {
+                playthroughCreationCallback = CharismaAPI.CreateConversation(token: tokenResponse.Token, callback: conversationUuid =>
+                {
+                    _conversationUuid = conversationUuid;
+
+                    _charisma = new Playthrough(
+                        tokenResponse.Token,
+                        tokenResponse.PlaythroughUuid
+                    );
+
+                    _charisma.Connect(onReadyCallback: () =>
+                    {
+                        _charisma.Start(_conversationUuid);
+
+                        forkPlaythrough = CharismaAPI.ForkPlaythroughToken(tokenResponse.Token, callback: (response) =>
+                        {
+                            getForkedPlaythroughInfoCall = CharismaAPI.GetPlaythroughInfo(response.NewToken, callback: (result) =>
+                            {
+                                forkedPlaythroughInfo = result;
+                            });
+                        });
+                    });
+                });
+
+                getDraftPlaythroughInfoCall = CharismaAPI.GetPlaythroughInfo(tokenResponse.Token, callback: (playthroughInfoResult) =>
+                {
+                    draftPlaythroughInfo = playthroughInfoResult;
+                });
+
+            });
+
+            // adding padding to accomodate for token generation
+            yield return StartAndWaitUntil(createPlaythroughToken, () =>
+            {
+                return playthroughCreationCallback != default;
+            });
+
+            yield return StartAndWaitUntil(playthroughCreationCallback, () =>
+            {
+                return getDraftPlaythroughInfoCall != default;
+            });
+
+
+            yield return StartAndWaitUntil(getDraftPlaythroughInfoCall, () =>
+            {
+                return forkPlaythrough != default;
+            });
+
+            yield return StartAndWaitUntil(forkPlaythrough, () =>
+            {
+                return getForkedPlaythroughInfoCall != default;
+            });
+
+            yield return getForkedPlaythroughInfoCall;
+
+            // to identify succesful fork, draft version feature a single Actor
+            // while forked version features two
+            Assert.AreNotEqual(draftPlaythroughInfo.Emotions.Length, forkedPlaythroughInfo.Emotions.Length, message: "Draft and Forked playthrough have the same count, which is not expected.");
+        }
+
+        #endregion
+
+        #region Private Helpers
+        static public IEnumerator StartAndWaitUntil(IEnumerator enumerator, Func<bool> condition, float timeout = 10f)
+        {
+            yield return enumerator;
+
+            yield return WaitUntil(condition, timeout);
+        }
+
+        static public IEnumerator WaitUntil(Func<bool> condition, float timeout = 10f)
+        {
+            float timePassed = 0f;
+            while (!condition() && timePassed < timeout)
+            {
+                yield return new WaitForEndOfFrame();
+                timePassed += Time.deltaTime;
+            }
+            if (timePassed >= timeout)
+            {
+                throw new TimeoutException("Condition was not fulfilled for " + timeout + " seconds.");
+            }
+        }
+
+        #endregion
+
+    }
+}

--- a/Scripts/Tests/ApiTests.cs
+++ b/Scripts/Tests/ApiTests.cs
@@ -81,7 +81,7 @@ namespace CharismaSDK.Tests
         [UnityTest]
         public IEnumerator GetMessageHistory([ValueSource("_validParameters")] CreatePlaythroughTokenParams parameterSet)
         {
-            
+            bool hasConnected = false;
 
             GetMessageHistoryResponse messageHistory = default;
 
@@ -112,6 +112,7 @@ namespace CharismaSDK.Tests
                     _charisma.Connect(onReadyCallback: () =>
                     {
                         _charisma.Start(_conversationUuid);
+                        hasConnected = true;
                     });
                 });
             });
@@ -121,7 +122,7 @@ namespace CharismaSDK.Tests
             // adding padding to accomodate for server response waiting time
             yield return StartAndWaitUntil(playthroughCreationCallback, () =>
             {
-                return _charisma.IsReadyToPlay;
+                return hasConnected;
             });
 
             // send conversation reply
@@ -321,6 +322,7 @@ namespace CharismaSDK.Tests
 
             bool triggeredOnMessageCallback = false;
             long firstMessageId = 0;
+            bool hasConnected = false;
 
             IEnumerator createToken = CharismaAPI.CreatePlaythroughToken(parameterSet, callback: (tokenResponse) =>
             {
@@ -364,6 +366,7 @@ namespace CharismaSDK.Tests
                     _charisma.Connect(onReadyCallback: () =>
                     {
                         _charisma.Start(_conversationUuid);
+                        hasConnected = true;
                     });
                 });
             });
@@ -373,7 +376,7 @@ namespace CharismaSDK.Tests
             // adding padding to accomodate for server response waiting time
             yield return StartAndWaitUntil(playthroughCreationCallback, () =>
             {
-                return _charisma.IsReadyToPlay;
+                return hasConnected;
             });
 
             // send conversation reply

--- a/Scripts/Tests/ApiTests.cs.meta
+++ b/Scripts/Tests/ApiTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4897e5b68a03cfd48bbf8ee60548c995
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tests/CharismaApiTestData.cs
+++ b/Scripts/Tests/CharismaApiTestData.cs
@@ -1,0 +1,77 @@
+#if UNITY_EDITOR
+
+using UnityEngine;
+
+namespace CharismaSDK.Tests
+{
+    [System.Serializable]
+    [CreateAssetMenu(menuName = "Charisma/Testing/ApiTestData", fileName = "NewApiTestData")]
+    public class CharismaApiTestData : ScriptableObject
+    {
+        public int StoryId => _storyId;
+        public int StoryVersion => _storyVersion;
+        public string ApiKey => _apiKey;
+
+        public string FirstReply => _firstReply;
+        public string FirstExpectedMessage => _firstExpectedMessage;
+        public string SecondReply => _secondReply;
+        public string SecondExpectedMessage => _secondExpectedMessage;
+
+        public bool HasMemoryValue => !string.IsNullOrEmpty(MemoryRecallValue) && !string.IsNullOrEmpty(MemorySaveValue);
+
+        public string MemoryRecallValue => _memoryRecallValue;
+        public string MemorySaveValue => _memorySaveValue;
+
+        public bool HasPublishedPlaythroughForFork => _hasPublishedPlaythroughAndDraft;
+
+        public int DraftActorCount => _draftActorCount;
+        public int ForkActorCount => _forkActorCount;
+
+        [Space(10)]
+
+        [Header(header: "Playthrough Information")]
+        [SerializeField]
+        private int _storyId;
+        [SerializeField]
+        private int _storyVersion;
+        [SerializeField]
+        private string _apiKey;
+
+        [Header(header: "Expected Test/Story Data")]
+        [SerializeField]
+        [Tooltip("First reply to send to the story.")]
+        private string _firstReply;
+        [SerializeField]
+        [Tooltip("First expected message to be received from Charisma API. Used in GetMessageHistory test")]
+        private string _firstExpectedMessage;
+        [SerializeField]
+        [Tooltip("Second reply to send to the story.")]
+        private string _secondReply;
+        [SerializeField]
+        [Tooltip("Second expected message to be received from Charisma API. Used in GetMessageHistory test")]
+        private string _secondExpectedMessage;
+
+        [Space(10)]
+
+        [SerializeField]
+        [Tooltip("Memory recall value, only use if Playthrough has a valid memory.")]
+        private string _memoryRecallValue;
+        [SerializeField]
+        [Tooltip("Memory Save Value, to be registered to the Memory defined by the RecallValue above. Used in SetMemory test")]
+        private string _memorySaveValue;
+
+        [Space(10)]
+
+        [SerializeField]
+        [Tooltip("Set to true if Playthrough has both published and draft versions. For ForkPlaythrough test")]
+        private bool _hasPublishedPlaythroughAndDraft;
+        [SerializeField]
+        [Tooltip("Number of actor the draft version of the story has. Should be different from ForkActorCount. For ForkPlaythrough test")]
+        private int _draftActorCount;
+        [SerializeField]
+        [Tooltip("Number of actor the forked/published version of the story has. Should be different from DraftActorCount. For ForkPlaythrough test")]
+        private int _forkActorCount;
+    }
+}
+
+#endif

--- a/Scripts/Tests/CharismaApiTestData.cs.meta
+++ b/Scripts/Tests/CharismaApiTestData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a1b24652961354d4389ca39ae3002bba
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Scripts/Tests/CharismaSDK.Tests.asmdef
+++ b/Scripts/Tests/CharismaSDK.Tests.asmdef
@@ -1,0 +1,11 @@
+{
+	"name": "CharismaSDK.Tests",
+	"references": [
+	"CharismaSDK"
+	],
+	"optionalUnityReferences": [
+	"TestAssemblies"
+	],
+	"includePlatforms": [],
+	"excludePlatforms": []
+}

--- a/Scripts/Tests/CharismaSDK.Tests.asmdef.meta
+++ b/Scripts/Tests/CharismaSDK.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 0da4596a82bac5c42b9604dfd30f60fd
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- added following API endpoints: GetPlaythroughInfo
GetMessageHistory
ForkPlaythrough
- split SetMemory endpoint into two variants(single, and collection), former calling the latter as an overload
- added unit tests for all the API functions
- added missing data structures that were featured in other implementations. notably serverResponses, but also Impacts
- added http.dispose calls, as they were triggering an error that was causing the tests to fail. quite duplicate as its in every api call; no clear way to streamline this right now, outside of adding an http wrapper, but seems overkill for this PR

Notes:
- regarding the unit tests, due to the need for async API calls and waiting for server callbacks, had to opt to use [UnityTest] framework instead of the more flexible [TestCase] from Nunit. this means we lose on the ability to provide parameters to these tests and need to rely on a constant story parameters used for testing
- in the future, may be worth looking more into using [TestCase] specifically, but for the time being this is ok. main downside is we won't be able to provide users w/ a testsuite for their own stories, but it does work as a set of examples of how the system works.
- had to move CharismaAPI and CharismaAPI.Tests into separate assembly definitions as a requirement of this change. doesnt affect existing examples and likely wont affect users significantly outside of needing a ref in their own assemblies

Closes #9 