### PR TITLE
removed confidence and durationInSeconds

### DIFF
--- a/Scripts/Events.cs
+++ b/Scripts/Events.cs
@@ -30,10 +30,6 @@ namespace CharismaSDK.Events
     [Serializable]
     public class SpeechRecognitionResult
     {
-        public float confidence;
-
-        public float durationInSeconds;
-
         public bool speechFinal;
 
         public bool isFinal;


### PR DESCRIPTION
- these do not seem to unpack correctly
- removed to ensure parity with unreal version of the sdk as well