### PR TITLE
fix: improved support for WebGL builds

### DIFF
--- a/Scripts/Sound/CharismaAudio.jslib
+++ b/Scripts/Sound/CharismaAudio.jslib
@@ -1,0 +1,15 @@
+mergeInto(LibraryManager.library, {
+  SaveBufferAsBlob: function (bufferPointer, bufferSize) {
+    const bytes = new Uint8Array(bufferSize);
+    for (let i = 0; i < bufferSize; i += 1) {
+      bytes[i] = HEAPU8[bufferPointer + i];
+    }
+    const blob = new Blob([bytes]);
+    const blobUrl = window.URL.createObjectURL(blob);
+
+    const returnBufferSize = lengthBytesUTF8(blobUrl) + 1;
+    const returnBuffer = _malloc(returnBufferSize);
+    stringToUTF8(blobUrl, returnBuffer, returnBufferSize);
+    return returnBuffer;
+  }
+});

--- a/Scripts/Sound/CharismaAudio.jslib.meta
+++ b/Scripts/Sound/CharismaAudio.jslib.meta
@@ -1,0 +1,32 @@
+fileFormatVersion: 2
+guid: 44f1c35cd080144d6b1e9a4bcdf4e7b1
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 1
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        DefaultValueInitialized: true
+  - first:
+      WebGL: WebGL
+    second:
+      enabled: 1
+      settings: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
- Patch to the MsgPack deserialiser ([as implemented upstream in the `msgpack-unity3d` library](https://github.com/deniszykov/msgpack-unity3d/blob/master/src/GameDevWare.Serialization.Unity/Assets/Plugins/GameDevWare.Serialization/Metadata/MetadataReflection.cs))
- Use native browser `Blob` (via a `.jslib`) instead of local file storage for text-to-speech payloads, since browsers forbid access to local file storage